### PR TITLE
Update meross_control : add uuid,from to header

### DIFF
--- a/meross_control
+++ b/meross_control
@@ -35,7 +35,7 @@ MESSAGEID=$(uuid | md5sum | awk '{print $1}')
 SIGNATURE=$(echo -n $MESSAGEID$KEY$TIMESTAMP | md5sum | awk '{print $1}')
 
 TOPIC="/appliance/$MEROSS_DEVICEID/subscribe"
-HEADER="{\"messageId\":\"$MESSAGEID\",\"namespace\":\"$NAMESPACE\",\"method\":\"SET\",\"payloadVersion\":1,\"sign\":\"$SIGNATURE\",\"timestamp\":$TIMESTAMP}"
+HEADER="{\"messageId\":\"$MESSAGEID\",\"namespace\":\"$NAMESPACE\",\"method\":\"SET\",\"payloadVersion\":1,\"sign\":\"$SIGNATURE\",\"timestamp\":$TIMESTAMP,\"uuid\":\"$MEROSS_DEVICEID\",\"from\":\"dummy\"}"
 PAYLOAD="{\"togglex\":{\"channel\":0,$ACTION}}"
 
 if [ "x$DEBUG" != "x" ]; then


### PR DESCRIPTION
手元のMerossスマートプラグ
( 2021年8月購入 mss110 un rtl8710cm (hardware:7.0.0 firmware:7.2.3) )
では，ファームウェアのバージョンが新しいものであるためか，
ヘッダにuuidとfromフィールドを追加しないとSETコマンドが通らないようです．

fromフィールドの値は，0文字ではどうやら不具合がある（スイッチのオンオフに成功するときもあるが，コマンドが通らずLEDが赤くなることもある）ため，ダミー文字列"dummy"としています．